### PR TITLE
修复对transformRequest transformResponse merge时覆盖的问题

### DIFF
--- a/examples/client/index.js
+++ b/examples/client/index.js
@@ -12,11 +12,18 @@ axios.interceptors.request.use(function (e) {
   return e
 })
 
-// axios.defaults.withCredentials = true
+axios.defaults.transformRequest = [function axiosTest (data) {
+  console.log('axios默认的transformRequest', data)
+  return data
+}]
 // console.log(axiosService)
 axiosService.init(axios, {
   defaults: {
-    withCredentials: true
+    withCredentials: false,
+    transformRequest: [function testTransformRequest (data) {
+      console.log('axiosService透传的transformRequest', data)
+      return data
+    }]
   },
   requestDefaults: {
     autoLoading: true,

--- a/src/service.js
+++ b/src/service.js
@@ -1,5 +1,5 @@
 import { defaults } from './config'
-import { extend } from './utils'
+import { extend, deepMerge } from './utils'
 
 export default class Service {
   constructor (options = {}) {
@@ -24,7 +24,7 @@ export default class Service {
 
   setDefaults (newConfig) {
     // 一定要保留this.$http.defaults旧地址引用不变
-    extend(this.$http.defaults, { ...defaults, ...newConfig })
+    extend(this.$http.defaults, deepMerge(this.$http.defaults, defaults, newConfig))
   }
 
   setRequestDefaults (newRequestOpts = {}) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,6 +27,10 @@ export const isArray = function (val) {
   return toString.call(val) === '[object Array]';
 }
 
+export const isMustObject = function (val) {
+  return toString.call(val) === '[object Object]';
+}
+
 /**
  * Determine if a value is a String
  *
@@ -149,19 +153,27 @@ export function merge(/* obj1, obj2, obj3, ... */) {
  */
 export function deepMerge(/* obj1, obj2, obj3, ... */) {
   var result = {}
-  function assignValue(val, key) {
-    if (typeof result[key] === 'object' && typeof val === 'object') {
-      result[key] = deepMerge(result[key], val)
-    } else if (typeof val === 'object') {
-      result[key] = deepMerge({}, val)
+  function assignValue (target, source) {
+    if (isMustObject(target) && isMustObject(source)) {
+      Object.keys(source).forEach(sourceKey => {
+        if (!target[sourceKey]) {
+          target[sourceKey] = source[sourceKey]
+        } else {
+          target[sourceKey] = deepMerge(target[sourceKey], source[sourceKey])
+        }
+      })
+    } else if (isArray(target) && isArray(source)) {
+      target = target.concat(source)
     } else {
-      result[key] = val
+      target = source
     }
+    return target
   }
 
   for (var i = 0, l = arguments.length; i < l; i++) {
-    forEach(arguments[i], assignValue)
+    result = assignValue(result, arguments[i])
   }
+
   return result
 }
 


### PR DESCRIPTION
### 修复transformRequest transformResponse merge时覆盖的问题

- 增加mergeTransfrom 高阶函数 功能是连接数组（不改变引用）
- 重写deepMerge 支持数组的合并
- postXform postXformString 方法改用transformRequest处理data
- 修改一处错误文案
- 修改例子